### PR TITLE
Proxy smart contract for Tezos

### DIFF
--- a/tezos/tezos-proxy-contract/tns-proxy.liq
+++ b/tezos/tezos-proxy-contract/tns-proxy.liq
@@ -1,6 +1,6 @@
-(* Title: Tezos Name Service Proxy *)
+(* Title: Tezos Proxy Contract *)
 (* Author: Teckhua Chiang *)
-(* Company: Cryptonomic *)
+(* Company: Cryptonomic Inc. *)
 
 [%%version 1.04] 
 
@@ -13,16 +13,15 @@ type storage = {
 let%init storage = {
   owner = Current.sender ();
   redirect = Current.sender ();
-  stamp = "Author: Teckhua Chiang, Company: Cryptonomic";
+  stamp = "Author: Teckhua Chiang, Company: Cryptonomic Inc.";
 } 
   
-(* Allows owner to set subnode owner *)
+(* Allows the owner to set the redirect address *)
 let%entry setRedirect
     ((redirect : address))
-    storage = 
-  (* Check if sender is the owner *)
+    storage =
   if Current.sender () = storage.owner then
     let storage = storage.redirect <- redirect in
     ([], storage)
   else 
-    failwith ("You do not own the Tezos Name Service proxy")
+    failwith ("You do not own this proxy contract")

--- a/tezos/tezos-proxy-contract/tns-proxy.tz
+++ b/tezos/tezos-proxy-contract/tns-proxy.tz
@@ -1,6 +1,6 @@
-# Title: Tezos Name Service Proxy
+# Title: Tezos Proxy Contract
 # Author: Teckhua Chiang
-# Company: Cryptonomic
+# Company: Cryptonomic Inc.
 
 parameter address;
 storage (pair :storage (address %owner) (pair (address %redirect) (string %stamp)));
@@ -24,5 +24,5 @@ code { DUP ;
             PAIR @storage %owner ;
             NIL operation ;
             PAIR }
-          { PUSH string "You do not own the Tezos Name Service proxy" ; FAILWITH } ;
+          { PUSH string "You do not own this proxy contract" ; FAILWITH } ;
        DIP { DROP ; DROP } };


### PR DESCRIPTION
Addresses #5. This PR includes a proxy smart contract that stores an owner address and redirect address. Users can always refer to this same smart contract for the address of another smart contract, allowing the owner to update the redirect address to an upgraded smart contract without interruption to service. The proxy contract allows the owner to update the stored redirect address.